### PR TITLE
🐛 ChatRoom Page 스타일 에러 수정

### DIFF
--- a/src/components/Chat/MessageBox/MessageBox.tsx
+++ b/src/components/Chat/MessageBox/MessageBox.tsx
@@ -18,13 +18,15 @@ export const MessageBox = ({ sendMessage, setToBottom }: Props) => {
       | React.KeyboardEvent<HTMLTextAreaElement>
   ) => {
     e.preventDefault();
-    sendMessage({
-      sender: 'me',
-      content: input,
-      send_at: new Date()
-    });
-    setToBottom(true);
-    setInput('');
+    if (input) {
+      sendMessage({
+        sender: 'me',
+        content: input,
+        send_at: new Date()
+      });
+      setToBottom(true);
+      setInput('');
+    }
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/src/components/Chat/MessageItem/styles.ts
+++ b/src/components/Chat/MessageItem/styles.ts
@@ -6,6 +6,7 @@ export const MessageItemContainer = styled.li`
   &.my-message {
     justify-content: flex-end;
     p {
+      margin-left: 5px;
       color: ${({ theme }) => theme.color.text_white};
       background-color: ${({ theme }) => theme.color.main};
     }
@@ -16,16 +17,19 @@ export const MessageItemContainer = styled.li`
     border-radius: 50%;
   }
   p {
+    max-width: 80%;
     margin-left: 10px;
+    margin-right: 5px;
     padding: 10px 12px;
     font-size: 14px;
     background-color: ${({ theme }) => theme.color.msg_bg};
     border-radius: 20px;
-    margin-right: 5px;
     white-space: pre-wrap;
     line-height: 1.3;
   }
   span {
+    align-self: flex-end;
+    margin-bottom: 10px;
     font-size: 13px;
     color: #aaa;
   }

--- a/src/components/Common/PageHeader/PageHeader.tsx
+++ b/src/components/Common/PageHeader/PageHeader.tsx
@@ -2,12 +2,13 @@ import * as S from './styles';
 
 interface Props {
   title: string;
+  backTo: string;
 }
 
-export const PageHeader = ({ title }: Props) => {
+export const PageHeader = ({ title, backTo }: Props) => {
   return (
     <S.PageHeaderContainer>
-      <S.BackIcon to="/chats">
+      <S.BackIcon to={backTo}>
         <img
           src="https://icons.iconarchive.com/icons/icons8/ios7/512/Arrows-Left-icon.png"
           alt="back_icon"

--- a/src/components/Common/PageHeader/styles.ts
+++ b/src/components/Common/PageHeader/styles.ts
@@ -5,6 +5,7 @@ export const PageHeaderContainer = styled.div`
   display: flex;
   align-items: center;
   position: relative;
+  width: 100%;
   height: ${({ theme }) => theme.style.header_height};
   padding: 0 ${({ theme }) => theme.style.edge_padding};
   border-bottom: 1px solid #dadada;

--- a/src/pages/ChatRoomPage/ChatRoomPage.tsx
+++ b/src/pages/ChatRoomPage/ChatRoomPage.tsx
@@ -20,7 +20,7 @@ export const ChatRoomPage = () => {
 
   return (
     <AppContainer>
-      <PageHeader title={name} />
+      <PageHeader title={name} backTo="/chats" />
       <MessageList
         sections={sections}
         profile={profile_image_url}


### PR DESCRIPTION
### 세부구현 사항들
- [x] PageHeader `width:100%` 추가
- [x] PageHeader 상단 뒤로가기 아이콘 링크는 `backTo` props로 넘겨주도록 설정
- [x] 채팅방페이지의 Message 보낸시간은 메세지 하단으로 위치하도록 수정
- [x] 채팅 입력이 있을 때만 전송되도록 설정 