### PR TITLE
✨ videoItem 클릭시 재생화면으로 이동하도록 페이지 라우팅 및 관련 컴포넌트 동적으로 수정

### DIFF
--- a/server/db.json
+++ b/server/db.json
@@ -145,7 +145,7 @@
     },
     {
       "id": 6,
-      "video_url": "https://vod-progressive.akamaized.net/exp=1651693995~acl=%2Fvimeo-prod-skyfire-std-us%2F01%2F3247%2F17%2F441235014%2F1930197928.mp4~hmac=1fb980efc3973c87dbdeeed06e17fbef646bbc6e4804857579d37d6ccf90f4a2/vimeo-prod-skyfire-std-us/01/3247/17/441235014/1930197928.mp4?filename=production+ID%3A4941597.mp4",
+      "video_url": "https://player.vimeo.com/external/441235014.hd.mp4?s=10bc99ecc3bc5bcac4496bb38e30ee7d35a0bc92&profile_id=174&oauth2_token_id=57447761",
       "thumbnail_url": "https://i.vimeocdn.com/video/929231251-3b14421050ae19d6f7792d56ba26cda375052031238aba14dbc2d3fd4c3e9793-d?mw=1100&mh=1957&q=70",
       "category": "vans",
       "title": "Vans Old Skool Orange",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ function App() {
             <Route path="upload" element={<VideoUploadPage />} />
             <Route path="chats" element={<ChatListPage />} />
             <Route path="profile" element={<ProfilePage />} />
+            <Route path="/video/:videoId" element={<MainPage />} />
           </Route>
           <Route path="/chat/:id" element={<ChatRoomPage />} />
           {/* <Route path="/login" element={} /> */}

--- a/src/components/Common/VideoItem/VideoItem.tsx
+++ b/src/components/Common/VideoItem/VideoItem.tsx
@@ -1,13 +1,16 @@
 import React, { useRef } from 'react';
+import { Link } from 'react-router-dom';
 import * as S from './styles';
 
 interface Props {
+  id: number,
   url: string;
   currentVideoRef: any;
   setCurrentVideoRef: Function;
 }
 
 export const VideoItem = ({
+  id,
   url,
   setCurrentVideoRef,
   currentVideoRef
@@ -24,7 +27,9 @@ export const VideoItem = ({
 
   return (
     <S.Wrap>
-      <video onMouseOver={playMovie} src={url} muted loop ref={videoRef} />
+      <Link to={`/video/${id}`}>
+        <video onMouseOver={playMovie} src={url} muted loop ref={videoRef} />
+      </Link>
     </S.Wrap>
   );
 };

--- a/src/components/Main/DescriptionBox/DescriptionBox.tsx
+++ b/src/components/Main/DescriptionBox/DescriptionBox.tsx
@@ -1,24 +1,19 @@
 import React from 'react';
 import * as S from './styles';
 
-export const DescriptionBox = () => {
+export const DescriptionBox = ({
+  title,
+  description
+}: {
+  title: string;
+  description: string;
+}) => {
   return (
     <S.ContentBox>
       <h1 className="price">129,000</h1>
-      <h2 className="name">나이키 에어맥스 97</h2>
+      <h2 className="name">{title}</h2>
       <span className="secondhand">중고</span>
-      <p className="desc">
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Molestiae
-        eveniet ex, porro est consequuntur, rerum sed enim nulla ad expedita
-        velit. Illum non architecto fugiat, ducimus cupiditate perferendis id
-        rerum! Officia cum ducimus illum et ut cupiditate enim excepturi,
-        provident dolorum blanditiis? Maiores, ex nesciunt nostrum doloribus
-        quidem repudiandae est similique qui amet esse commodi dolore! Vel eum
-        cupiditate molestiae! Dolorem enim ea quis labore, quasi porro ab
-        ratione nobis quam. Molestiae mollitia quod tempora debitis natus,
-        accusamus commodi suscipit dolorum quos quia in odio? Temporibus, natus.
-        Explicabo, reiciendis alias.
-      </p>
+      <p className="desc">{description}</p>
     </S.ContentBox>
   );
 };

--- a/src/components/Main/PlayerMenu/PlayerMenu.tsx
+++ b/src/components/Main/PlayerMenu/PlayerMenu.tsx
@@ -3,15 +3,16 @@ import * as S from './styles';
 import { FaHeart, FaShare } from 'react-icons/fa';
 import { BsChatDotsFill } from 'react-icons/bs';
 
-export const PlayerMenu = () => {
+export const PlayerMenu = ({
+  profile_image_url
+}: {
+  profile_image_url: string;
+}) => {
   return (
     <S.Wrap>
       <S.Nav>
         <S.Button>
-          <img
-            src="https://images.unsplash.com/photo-1593085512500-5d55148d6f0d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1180&q=80"
-            alt="profile"
-          />
+          <img src={profile_image_url} alt="profile" />
         </S.Button>
         <S.Button>
           <FaHeart className="icon" />

--- a/src/components/Main/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/Main/VideoPlayer/VideoPlayer.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef } from 'react';
 import * as S from './styles';
 import { IoPlayCircle, IoPauseCircle } from 'react-icons/io5';
 
-export const VideoPlayer = () => {
+export const VideoPlayer = ({ video_url }: { video_url: string }) => {
   const [isPlaying, setIsPlaying] = useState(true);
   const videoRef = useRef<any>(null);
 
@@ -30,7 +30,7 @@ export const VideoPlayer = () => {
         muted
         onClick={controlVideo}
         ref={videoRef}
-        src="https://player.vimeo.com/progressive_redirect/playback/672684920/rendition/540p/540p.mp4?loc=external&oauth2_token_id=57447761&signature=32cb6b2e5e97333e35129877a0a35748af0bec5798a5066753d36999a017a31a"
+        src={video_url}
       />
       {isPlaying ? (
         <S.ControlButton onClick={controlVideo}>

--- a/src/components/Profile/ProfileNavigation/ProfileNavigation.tsx
+++ b/src/components/Profile/ProfileNavigation/ProfileNavigation.tsx
@@ -42,6 +42,7 @@ export const ProfileNavigation = () => {
               <VideoItem
                 key={id}
                 url={video_url}
+                id={id}
                 setCurrentVideoRef={setCurrentVideoRef}
                 currentVideoRef={currentVideoRef}
               />
@@ -50,6 +51,7 @@ export const ProfileNavigation = () => {
               <VideoItem
                 key={id}
                 url={video_url}
+                id={id}
                 setCurrentVideoRef={setCurrentVideoRef}
                 currentVideoRef={currentVideoRef}
               />

--- a/src/data/types.d.ts
+++ b/src/data/types.d.ts
@@ -31,3 +31,17 @@ export interface IVideo {
   video_url: string;
   view_count: number;
 }
+
+export interface IVideoWithUser {
+  id: number;
+  category: string;
+  title: string;
+  description: string;
+  thumbnail_url: string;
+  video_url: string;
+  view_count: number;
+  user: {
+    name: string;
+    profile_image_url: string;
+  };
+}

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,13 +1,39 @@
-import { PlayerMenu, VideoPlayer, DescriptionBox, MainHeader } from 'components';
+import {
+  PlayerMenu,
+  VideoPlayer,
+  DescriptionBox,
+  MainHeader
+} from 'components';
 import * as S from './styles';
+import { useParams } from 'react-router-dom';
+import useSWR from 'swr';
+import { VIDEO_ITEM_API } from 'utils/api';
+import { fetcher } from 'utils/swr';
+import { IVideo } from 'data/types';
+import { Loading } from 'components';
 
 export const MainPage = () => {
+  const { videoId } = useParams();
+  const { data: videoData } = useSWR<IVideo>(
+    VIDEO_ITEM_API(Number(videoId)),
+    fetcher
+  );
+
   return (
     <S.Wrap>
-      <MainHeader />
-      <VideoPlayer />
-      <PlayerMenu />
-      <DescriptionBox />
+      {videoData ? (
+        <>
+          <MainHeader />
+          <VideoPlayer video_url={videoData.video_url} />
+          <PlayerMenu profile_image_url={videoData.profile_image_url} />
+          <DescriptionBox
+            title={videoData.title}
+            description={videoData.description}
+          />
+        </>
+      ) : (
+        <Loading />
+      )}
     </S.Wrap>
   );
 };

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -13,7 +13,7 @@ import { IVideoWithUser } from 'data/types';
 import { Loading } from 'components';
 
 export const MainPage = () => {
-  const { videoId } = useParams();
+  const { videoId = 6 } = useParams();
   const { data: videoData } = useSWR<IVideoWithUser>(
     VIDEO_ITEM_API(Number(videoId)),
     fetcher

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -9,12 +9,12 @@ import { useParams } from 'react-router-dom';
 import useSWR from 'swr';
 import { VIDEO_ITEM_API } from 'utils/api';
 import { fetcher } from 'utils/swr';
-import { IVideo } from 'data/types';
+import { IVideoWithUser } from 'data/types';
 import { Loading } from 'components';
 
 export const MainPage = () => {
   const { videoId } = useParams();
-  const { data: videoData } = useSWR<IVideo>(
+  const { data: videoData } = useSWR<IVideoWithUser>(
     VIDEO_ITEM_API(Number(videoId)),
     fetcher
   );
@@ -25,7 +25,7 @@ export const MainPage = () => {
         <>
           <MainHeader />
           <VideoPlayer video_url={videoData.video_url} />
-          <PlayerMenu profile_image_url={videoData.profile_image_url} />
+          <PlayerMenu profile_image_url={videoData.user.profile_image_url} />
           <DescriptionBox
             title={videoData.title}
             description={videoData.description}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -5,7 +5,11 @@ export const CHAT_LIST_API = `${BASE_URL}/v1/users/chatting`;
 export const CHAT_ROOM_API = (chat_room_id: number) =>
   `${BASE_URL}/v1/users/chatting/${chat_room_id}`;
 
-// Profile Page 
-// my -> :userId로 대체 
+// Profile Page
+// my -> :userId로 대체
 export const MY_VIDEOS_API = `${BASE_URL}/v1/users/my/videos`;
 export const MY_LIKES_API = `${BASE_URL}/v1/users/my/likes`;
+
+// Main Page (영상 재생)
+export const VIDEO_ITEM_API = (video_id: number) =>
+  `${BASE_URL}/v1/videos/${video_id}`;


### PR DESCRIPTION
### 세부구현 사항

- [x] videoItem 클릭시 (profile page의 업로드/좋아요 영상) video 재생화면으로 이동 구현
- [x] video 재생화면은 기존의 main page를 이용하여 구현 
- [x] 재생페이지 라우팅 추가 : videoId를 parameter로 받아서 해당 videoData를 fetch하여 렌더
- [x] mainpage의 하위 컴포넌트들 모두 동적 데이터를 사용해서 렌더되도록 수정
- [x] mainpage의 경우 videoId가 없어서 오류 발생 -> videoId의 기본값을 6으로 수정

### 커밋 오류
제가 앞서 pr을 날렸던 것 위에 구현을 해야해서 해당 브랜치를 머지한 상태에서 작업을 했는데 앞의 pr 커밋까지 같이 추가되었네요 ㅠㅠ 