### PR TITLE
♻️ 카카오 소셜 로그인 로직 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# api
+.env

--- a/src/components/Login/KakaoLogin/KakaoLogin.tsx
+++ b/src/components/Login/KakaoLogin/KakaoLogin.tsx
@@ -1,27 +1,11 @@
 import * as S from './styles';
 import kakaoButtonImage from 'assets/img/kakaoLogin.png';
-
-const REST_API_KEY = 'd5920e912464567168de709625674543';
-const REDIRECT_URI = 'http://localhost:3000/oauth/callback';
-const URL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+import { KAKAO_LOGIN_URL } from 'utils/api';
 
 export const KakaoLogin = () => {
-  // const handleClick = () => {
-  //   const fetchData = async () => {
-  //     const response = await fetch(
-  //       'https://bb20-175-203-19-50.jp.ngrok.io/oauth2/authorization/kakao'
-  //     );
-  //     const data = await response.json();
-  //     console.log('data', data);
-  //     // localStorage.setItem('token', data);
-  //   };
-
-  //   fetchData();
-  // };
-
   return (
     <>
-      <S.KakaoButton href={URL}>
+      <S.KakaoButton href={KAKAO_LOGIN_URL}>
         <img src={kakaoButtonImage} alt="login-btn" />
       </S.KakaoButton>
     </>

--- a/src/components/Login/KakaoLogin/KakaoRedirectHandler.tsx
+++ b/src/components/Login/KakaoLogin/KakaoRedirectHandler.tsx
@@ -2,8 +2,11 @@ import React, { useEffect } from 'react';
 import axios from 'axios';
 import { Loading } from 'components';
 import { TOKEN_API } from 'utils/api';
+import { useNavigate } from 'react-router-dom';
 
 export const KakaoRedirectHandler = () => {
+  const navigate = useNavigate();
+
   useEffect(() => {
     const loginWithKakao = async () => {
       const geJWTToken = async (authorizationCode: string) => {
@@ -15,6 +18,11 @@ export const KakaoRedirectHandler = () => {
           // 서버에서 발행한 자체 JWT 토큰 받기
           .then(res => {
             // console.log(res.data);
+
+            if (res.data.message !== '로그인 성공') {
+              alert('로그인에 성공하지 못했습니다.');
+            }
+
             const { name, email, token } = res.data.data;
             const accessToken = token.accessToken;
             const refreshToken = token.refreshToken;
@@ -23,6 +31,9 @@ export const KakaoRedirectHandler = () => {
             localStorage.setItem('email', email);
             localStorage.setItem('AC_Token', accessToken);
             localStorage.setItem('RF_Token', refreshToken);
+
+            alert('로그인에 성공하였습니다.');
+            navigate('/');
           });
       };
 
@@ -37,7 +48,7 @@ export const KakaoRedirectHandler = () => {
     };
 
     loginWithKakao();
-  }, []);
+  }, [navigate]);
 
   return <Loading />;
 };

--- a/src/components/Login/KakaoLogin/KakaoRedirectHandler.tsx
+++ b/src/components/Login/KakaoLogin/KakaoRedirectHandler.tsx
@@ -1,37 +1,43 @@
 import React, { useEffect } from 'react';
-import { Loading } from 'components';
 import axios from 'axios';
+import { Loading } from 'components';
+import { TOKEN_API } from 'utils/api';
 
 export const KakaoRedirectHandler = () => {
   useEffect(() => {
     const loginWithKakao = async () => {
+      const geJWTToken = async (authorizationCode: string) => {
+        await axios
+          //서버에 인가코드 전송
+          .post(TOKEN_API, {
+            code: authorizationCode
+          })
+          // 서버에서 발행한 자체 JWT 토큰 받기
+          .then(res => {
+            // console.log(res.data);
+            const { name, email, token } = res.data.data;
+            const accessToken = token.accessToken;
+            const refreshToken = token.refreshToken;
+            // let refreshToken = res.headers['refresh-token'];
+            localStorage.setItem('name', name);
+            localStorage.setItem('email', email);
+            localStorage.setItem('AC_Token', accessToken);
+            localStorage.setItem('RF_Token', refreshToken);
+          });
+      };
+
       //리다이렉트 페이지에서 인가코드 분리
       const url = new URL(window.location.href);
       const authorizationCode = url.searchParams.get('code');
       // console.log('인증 코드', authorizationCode);
+
       if (authorizationCode) {
         await geJWTToken(authorizationCode);
       }
     };
 
     loginWithKakao();
-
-    const geJWTToken = async (authorizationCode: any) => {
-      let tokenData = await axios
-        //서버에 인가코드 전송
-        .post('http://localhost:4000/users/kakao', {
-          authorizationCode
-        })
-        // 서버에서 발행한 자체 JWT 토큰 받기
-        .then(res => {
-          // console.log(res.data);
-          let accessToken = res.data.accessToken;
-          let refreshToken = res.headers['refresh-token'];
-          localStorage.setItem('CC_Token', accessToken);
-          localStorage.setItem('RF_Token', refreshToken);
-        });
-    };
   }, []);
-  
+
   return <Loading />;
 };

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -21,3 +21,9 @@ export const VIDEO_LIST_API = `${BASE_URL}/v1/videos`;
 // Search Page
 export const RECOMMENDED_VIDEO_API = `${BASE_URL}/v1/videos`;
 export const POPULAR_VIDEO_API = `${BASE_URL}/v1/videos`;
+
+// Login Page
+export const API_KEY = process.env.REACT_APP_KAKAO_API_KEY;
+export const KAKAO_REDIRECT_URI = 'http://localhost:3000/oauth/callback';
+export const KAKAO_LOGIN_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${API_KEY}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`;
+export const TOKEN_API = `${BASE_URL}/login/oauth2/code/kakao`;

--- a/src/utils/swr.ts
+++ b/src/utils/swr.ts
@@ -1,3 +1,12 @@
 import axios from 'axios';
 
 export const fetcher = (url: string) => axios.get(url).then(res => res.data);
+
+export const fetcherWithToken = (url: string, token: string) =>
+  axios
+    .get(url, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    })
+    .then(result => result.data);


### PR DESCRIPTION
### 세부구현 사항

- [x] API_KEY .env 파일에 분리
- [x] 토큰 및 닉네임, 이메일 로컬스토리지에 저장
- [x] 로그인 실패 예외처리, 성공시 홈으로 리다이렉트 설정
- [x] SWR 토큰용 fetcher 추가    

### 주의사항
- `useSWR(['/api/user', token], url => fetchWithToken(url, token))` : 토큰 업데이트시 다시 fetch해야하는 경우 사용