### PR TITLE
✨ Follow 추가/삭제 기능 구현 + 메인페이지 리팩토링

### DIFF
--- a/src/components/Admin/ContentsEdit/ContentsEdit.tsx
+++ b/src/components/Admin/ContentsEdit/ContentsEdit.tsx
@@ -92,7 +92,7 @@ export const ContentsEdit = () => {
             <S.TableData>
               <p className="title">Thumbnail</p>
               <span>
-                <img src={videoData.thumbnail_url} />
+                <img src={videoData.thumbnail_url} alt="" />
               </span>
             </S.TableData>
             <S.TableData>

--- a/src/components/ChatList/ChatItem/ChatItem.tsx
+++ b/src/components/ChatList/ChatItem/ChatItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as S from './styles';
 import { IChatList } from 'types';
 import { dateConverter } from 'utils/dateConverter';
+import { ProfileImage } from 'components';
 
 interface Prop {
   chatItem: IChatList;
@@ -16,7 +17,7 @@ export const ChatItem = ({ chatItem }: Prop) => {
 
   return (
     <S.ChatItemContainer>
-      <img src={profile_image_url} alt={name} />
+      <ProfileImage size="50" url={profile_image_url} />
       <S.ChatPreview>
         <p className="chat_user">
           {name}

--- a/src/components/ChatList/ChatItem/styles.ts
+++ b/src/components/ChatList/ChatItem/styles.ts
@@ -8,11 +8,6 @@ export const ChatItemContainer = styled.li`
   &:hover {
     background-color: ${({ theme }) => theme.color.nav_active_bg};
   }
-  img {
-    width: 50px;
-    height: 50px;
-    border-radius: 50px;
-  }
 `;
 
 export const ChatPreview = styled.div`

--- a/src/components/Common/ProfileImage/ProfileImage.tsx
+++ b/src/components/Common/ProfileImage/ProfileImage.tsx
@@ -1,0 +1,22 @@
+import * as S from './styles';
+
+interface Props {
+  size: string;
+  url: string;
+}
+
+export const ProfileImage = ({ size, url }: Props) => {
+  return (
+    <S.ImageContainer size={size}>
+      {url ? (
+        <img src={url} alt="profile" className="profile" />
+      ) : (
+        <img
+          src="https://user-images.githubusercontent.com/68415905/169463648-966ee0da-3dbd-4b4e-9eb5-104bd124e2b1.jpg"
+          alt="profile"
+          className="profile"
+        />
+      )}
+    </S.ImageContainer>
+  );
+};

--- a/src/components/Common/ProfileImage/styles.ts
+++ b/src/components/Common/ProfileImage/styles.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const ImageContainer = styled.div<{ size: string }>`
+  width: ${({ size }) => size + 'px'};
+  height: ${({ size }) => size + 'px'};
+  border-radius: 50%;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+`;

--- a/src/components/Common/VideoList/VideoList.tsx
+++ b/src/components/Common/VideoList/VideoList.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export const VideoList = ({ message, api }: Props) => {
-  const [_, setIsBottom] = useState(false);
+  const [, setIsBottom] = useState(false);
   const videoRef = useRef<IVideoListItem[]>([]);
   const lastVideoId = useRef<number | string>('');
   const scrollbarRef = useRef<Scrollbars>(null);

--- a/src/components/Main/ContentsWrap/ContentsWrap.tsx
+++ b/src/components/Main/ContentsWrap/ContentsWrap.tsx
@@ -42,14 +42,7 @@ export const ContentsWrap = ({
       videoData.user.name === localStorage.getItem('name') ? (
         <ControlMenu id={videoId} />
       ) : (
-        <PlayerMenu
-          profile_image_url={videoData.user.profile_image_url || ''}
-          isShown={isShown}
-          like_count={videoData.like_count}
-          userId={videoData.user.id}
-          videoId={videoId}
-          name={videoData.user.name}
-        />
+        <PlayerMenu videoData={videoData} isShown={isShown} videoId={videoId} />
       )}
       <DescriptionBox
         title={videoData.title}

--- a/src/components/Main/ContentsWrap/ContentsWrap.tsx
+++ b/src/components/Main/ContentsWrap/ContentsWrap.tsx
@@ -43,11 +43,7 @@ export const ContentsWrap = ({
         <ControlMenu id={videoId} />
       ) : (
         <PlayerMenu
-          profile_image_url={
-            videoData.user.profile_image_url
-              ? videoData.user.profile_image_url
-              : 'https://user-images.githubusercontent.com/68415905/166093018-2819a713-a7df-4703-bcd5-29b60507bdbf.jpg'
-          }
+          profile_image_url={videoData.user.profile_image_url || ''}
           isShown={isShown}
           like_count={videoData.like_count}
           userId={videoData.user.id}

--- a/src/components/Main/ContentsWrap/ContentsWrap.tsx
+++ b/src/components/Main/ContentsWrap/ContentsWrap.tsx
@@ -7,8 +7,8 @@ import { IVideoItem } from 'types';
 import {
   MainHeader,
   VideoPlayer,
-  PlayerMenu,
-  ControlMenu,
+  MyVideoNav,
+  UserVideoNav,
   DescriptionBox,
   Loading
 } from 'components';
@@ -32,7 +32,6 @@ export const ContentsWrap = ({
   if (!data) return <Loading />;
 
   const videoData = data?.data as IVideoItem;
-  // console.log(videoData);
 
   return (
     <S.Wrap>
@@ -40,15 +39,12 @@ export const ContentsWrap = ({
       <VideoPlayer video_url={videoData.video_url} />
       {type === 'delete' &&
       videoData.user.name === localStorage.getItem('name') ? (
-        <ControlMenu id={videoId} />
+        <MyVideoNav id={videoId} />
       ) : (
-        <PlayerMenu videoData={videoData} isShown={isShown} videoId={videoId} />
+        <UserVideoNav videoData={videoData} isShown={isShown} />
       )}
       <DescriptionBox
-        title={videoData.title}
-        description={videoData.description}
-        price={videoData.price}
-        used_status={videoData.used_status}
+        videoData={videoData}
         isShown={isShown}
         setIsShown={setIsShown}
       />

--- a/src/components/Main/DescriptionBox/DescriptionBox.tsx
+++ b/src/components/Main/DescriptionBox/DescriptionBox.tsx
@@ -1,26 +1,17 @@
 import React, { useEffect } from 'react';
+import { IVideoItem } from 'types';
 import * as S from './styles';
 
 interface Prop {
-  title: string;
-  description: string;
-  price: number;
-  used_status: boolean;
+  videoData: IVideoItem;
   isShown: boolean;
   setIsShown: Function;
 }
 
-export const DescriptionBox = ({
-  title,
-  description,
-  price,
-  used_status,
-  isShown,
-  setIsShown
-}: Prop) => {
-  const handleClick = () => {
-    setIsShown(!isShown);
-  };
+export const DescriptionBox = ({ videoData, isShown, setIsShown }: Prop) => {
+  const { title, description, price, used_status } = videoData;
+
+  const handleClick = () => setIsShown(!isShown);
 
   useEffect(() => {
     setIsShown(true);

--- a/src/components/Main/NavMenu/IconFeature/ChatButton.tsx
+++ b/src/components/Main/NavMenu/IconFeature/ChatButton.tsx
@@ -1,0 +1,10 @@
+import { ReactComponent as ChatIcon } from 'assets/svg/chat.svg';
+import { Button } from './styles';
+
+export const ChatButton = () => {
+  return (
+    <Button>
+      <ChatIcon className="icon" />
+    </Button>
+  );
+};

--- a/src/components/Main/NavMenu/IconFeature/LikeButton.tsx
+++ b/src/components/Main/NavMenu/IconFeature/LikeButton.tsx
@@ -1,23 +1,17 @@
-import { useEffect, useState } from 'react';
 import axios from 'axios';
-import * as S from './styles';
+import { Button } from './styles';
+import { useEffect, useState } from 'react';
 import { ReactComponent as SaveIcon } from 'assets/svg/save.svg';
 import { ReactComponent as UnSaveIcon } from 'assets/svg/unSave.svg';
-import { ReactComponent as ChatIcon } from 'assets/svg/chat.svg';
-import { ReactComponent as MoreIcon } from 'assets/svg/more.svg';
 import { LIKE_API, UNLIKE_API } from 'utils/api';
-import { ProfileFollow } from './IconFeature';
-import { IVideoItem } from 'types';
 
-interface Prop {
-  videoData: IVideoItem;
-  isShown: boolean;
+interface Props {
   videoId: number;
+  like_count: number;
 }
 
-export const PlayerMenu = ({ isShown, videoId, videoData }: Prop) => {
+export const LikeButton = ({ videoId, like_count }: Props) => {
   const [isLiked, setIsLiked] = useState(false);
-  const { like_count, user } = videoData;
 
   useEffect(() => {
     const checkLike = async () => {
@@ -67,22 +61,13 @@ export const PlayerMenu = ({ isShown, videoId, videoData }: Prop) => {
   };
 
   return (
-    <S.Wrap isShown={isShown}>
-      <ProfileFollow userData={user} />
-      <S.Button>
-        {isLiked ? (
-          <SaveIcon className="icon" onClick={handleLike} />
-        ) : (
-          <UnSaveIcon className="icon" onClick={handleLike} />
-        )}
-        <p>{like_count}</p>
-      </S.Button>
-      <S.Button>
-        <ChatIcon className="icon" />
-      </S.Button>
-      <S.Button>
-        <MoreIcon className="icon" />
-      </S.Button>
-    </S.Wrap>
+    <Button>
+      {isLiked ? (
+        <SaveIcon className="icon" onClick={handleLike} />
+      ) : (
+        <UnSaveIcon className="icon" onClick={handleLike} />
+      )}
+      <p className="likes">{like_count}</p>
+    </Button>
   );
 };

--- a/src/components/Main/NavMenu/IconFeature/MoreButton.tsx
+++ b/src/components/Main/NavMenu/IconFeature/MoreButton.tsx
@@ -1,0 +1,10 @@
+import { Button } from './styles';
+import { ReactComponent as MoreIcon } from 'assets/svg/more.svg';
+
+export const MoreButton = () => {
+  return (
+    <Button>
+      <MoreIcon className="icon" />
+    </Button>
+  );
+};

--- a/src/components/Main/NavMenu/IconFeature/ProfileFollow.tsx
+++ b/src/components/Main/NavMenu/IconFeature/ProfileFollow.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { Link } from 'react-router-dom';
 import { FOLLOWING_API, FOLLOW_API } from 'utils/api';
-import { Button } from '../styles';
+import { Button } from './styles';
 import { ProfileImage } from 'components';
 import { IFollow, IUser } from 'types';
 import { ReactComponent as FollowIcon } from 'assets/svg/follow.svg';

--- a/src/components/Main/NavMenu/IconFeature/ProfileFollow.tsx
+++ b/src/components/Main/NavMenu/IconFeature/ProfileFollow.tsx
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import { Link } from 'react-router-dom';
+import { FOLLOWING_API, FOLLOW_API } from 'utils/api';
+import { Button } from '../styles';
+import { ProfileImage } from 'components';
+import { IFollow, IUser } from 'types';
+import { ReactComponent as FollowIcon } from 'assets/svg/follow.svg';
+import useSWR from 'swr';
+import { fetcher } from 'utils/swr';
+
+interface Props {
+  userData: IUser;
+}
+
+export const ProfileFollow = ({ userData }: Props) => {
+  const { id, name, profile_image_url } = userData;
+  const { data: follow, mutate } = useSWR(FOLLOWING_API(36), fetcher);
+  const followData = follow?.data as IFollow[];
+  const isFollowed =
+    followData && followData.findIndex(({ member }) => member.id === id) !== -1;
+
+  const handleFollow = () => {
+    const config = {
+      method: 'post',
+      url: FOLLOW_API(id),
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem('AC_Token')}`
+      }
+    };
+    axios(config)
+      .then(() => {
+        mutate();
+      })
+      .catch(error => console.log(error));
+  };
+
+  return (
+    <Button>
+      <Link to={`/${name}`} state={{ userId: id }}>
+        <ProfileImage size="48" url={profile_image_url} />
+      </Link>
+      {!isFollowed && <FollowIcon className="follow" onClick={handleFollow} />}
+    </Button>
+  );
+};

--- a/src/components/Main/NavMenu/IconFeature/index.ts
+++ b/src/components/Main/NavMenu/IconFeature/index.ts
@@ -1,0 +1,1 @@
+export { ProfileFollow } from './ProfileFollow';

--- a/src/components/Main/NavMenu/IconFeature/index.ts
+++ b/src/components/Main/NavMenu/IconFeature/index.ts
@@ -1,1 +1,4 @@
 export { ProfileFollow } from './ProfileFollow';
+export { LikeButton } from './LikeButton';
+export { ChatButton } from './ChatButton';
+export { MoreButton } from './MoreButton';

--- a/src/components/Main/NavMenu/IconFeature/styles.ts
+++ b/src/components/Main/NavMenu/IconFeature/styles.ts
@@ -1,37 +1,19 @@
 import styled from 'styled-components';
 
-export const Wrap = styled.div<{ isShown: boolean }>`
-  display: ${props => (props.isShown ? 'flex' : 'none')};
-  position: absolute;
-  right: ${({ theme }) => theme.style.edge_padding};
-  bottom: 35px;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
-  z-index: 1000;
-
-  &.controller {
-    bottom: 200px;
-  }
-`;
-
 export const Button = styled.button`
   position: relative;
   width: 100%;
   & + & {
     margin-top: 45px;
   }
-
-  &:nth-of-type(even) {
-    margin-top: 38px;
+  &:nth-of-type(3) {
+    margin-top: 35px;
   }
-
-  p {
+  p.likes {
     font-size: 12px;
     margin-top: 5px;
     color: white;
   }
-
   .follow {
     width: 18px;
     height: 18px;
@@ -51,13 +33,5 @@ export const Button = styled.button`
   &:nth-of-type(2) .icon {
     width: 27px;
     height: 27px;
-  }
-
-  &.control {
-    width: 50px;
-    height: 50px;
-    background-color: #545454;
-    color: white;
-    border-radius: 50%;
   }
 `;

--- a/src/components/Main/NavMenu/MyVideoNav/MyVideoNav.tsx
+++ b/src/components/Main/NavMenu/MyVideoNav/MyVideoNav.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import * as S from './styles';
 import { DeleteModal } from 'components';
 
-export const ControlMenu = ({ id }: { id: number }) => {
+export const MyVideoNav = ({ id }: { id: number }) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const handleDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -10,9 +10,9 @@ export const ControlMenu = ({ id }: { id: number }) => {
   };
 
   return (
-    <S.Wrap isShown={true} className="controller">
-      {isDeleteModalOpen ? ( 
-        <DeleteModal setIsDeleteModalOpen={setIsDeleteModalOpen} id={id}/>
+    <S.MyNavWrap isShown={true}>
+      {isDeleteModalOpen ? (
+        <DeleteModal setIsDeleteModalOpen={setIsDeleteModalOpen} id={id} />
       ) : (
         <>
           <S.Button className="control" onClick={handleDelete}>
@@ -21,6 +21,6 @@ export const ControlMenu = ({ id }: { id: number }) => {
           <S.Button className="control">수정</S.Button>
         </>
       )}
-    </S.Wrap>
+    </S.MyNavWrap>
   );
 };

--- a/src/components/Main/NavMenu/MyVideoNav/styles.ts
+++ b/src/components/Main/NavMenu/MyVideoNav/styles.ts
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+import { Wrap } from '../UserVideoNav/styles';
+
+export const MyNavWrap = styled(Wrap)`
+  bottom: 200px;
+`;
+
+export const Button = styled.button`
+  position: relative;
+  width: 100%;
+  & + & {
+    margin-top: 45px;
+  }
+  &.control {
+    width: 50px;
+    height: 50px;
+    background-color: #545454;
+    color: white;
+    border-radius: 50%;
+  }
+`;

--- a/src/components/Main/NavMenu/PlayerMenu.tsx
+++ b/src/components/Main/NavMenu/PlayerMenu.tsx
@@ -1,33 +1,23 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import * as S from './styles';
-import { ReactComponent as FollowIcon } from 'assets/svg/follow.svg';
 import { ReactComponent as SaveIcon } from 'assets/svg/save.svg';
 import { ReactComponent as UnSaveIcon } from 'assets/svg/unSave.svg';
 import { ReactComponent as ChatIcon } from 'assets/svg/chat.svg';
 import { ReactComponent as MoreIcon } from 'assets/svg/more.svg';
 import { LIKE_API, UNLIKE_API } from 'utils/api';
-import { Link } from 'react-router-dom';
-import { ProfileImage } from 'components/Common/ProfileImage/ProfileImage';
+import { ProfileFollow } from './IconFeature';
+import { IVideoItem } from 'types';
 
 interface Prop {
-  profile_image_url: string;
+  videoData: IVideoItem;
   isShown: boolean;
-  like_count: number;
   videoId: number;
-  userId: number;
-  name: string;
 }
 
-export const PlayerMenu = ({
-  profile_image_url,
-  isShown,
-  like_count,
-  userId,
-  videoId,
-  name
-}: Prop) => {
+export const PlayerMenu = ({ isShown, videoId, videoData }: Prop) => {
   const [isLiked, setIsLiked] = useState(false);
+  const { like_count, user } = videoData;
 
   useEffect(() => {
     const checkLike = async () => {
@@ -78,12 +68,7 @@ export const PlayerMenu = ({
 
   return (
     <S.Wrap isShown={isShown}>
-      <S.Button>
-        <Link to={`/${name}`} state={{ userId: userId }}>
-          <ProfileImage size="48" url={profile_image_url} />
-        </Link>
-        <FollowIcon className="follow" />
-      </S.Button>
+      <ProfileFollow userData={user} />
       <S.Button>
         {isLiked ? (
           <SaveIcon className="icon" onClick={handleLike} />

--- a/src/components/Main/NavMenu/PlayerMenu.tsx
+++ b/src/components/Main/NavMenu/PlayerMenu.tsx
@@ -8,6 +8,7 @@ import { ReactComponent as ChatIcon } from 'assets/svg/chat.svg';
 import { ReactComponent as MoreIcon } from 'assets/svg/more.svg';
 import { LIKE_API, UNLIKE_API } from 'utils/api';
 import { Link } from 'react-router-dom';
+import { ProfileImage } from 'components/Common/ProfileImage/ProfileImage';
 
 interface Prop {
   profile_image_url: string;
@@ -79,7 +80,7 @@ export const PlayerMenu = ({
     <S.Wrap isShown={isShown}>
       <S.Button>
         <Link to={`/${name}`} state={{ userId: userId }}>
-          <img src={profile_image_url} alt="profile" />
+          <ProfileImage size="48" url={profile_image_url} />
         </Link>
         <FollowIcon className="follow" />
       </S.Button>

--- a/src/components/Main/NavMenu/UserVideoNav/UserVideoNav.tsx
+++ b/src/components/Main/NavMenu/UserVideoNav/UserVideoNav.tsx
@@ -1,0 +1,26 @@
+import {
+  ChatButton,
+  LikeButton,
+  MoreButton,
+  ProfileFollow
+} from '../IconFeature';
+import * as S from './styles';
+import { IVideoItem } from 'types';
+
+interface Prop {
+  videoData: IVideoItem;
+  isShown: boolean;
+}
+
+export const UserVideoNav = ({ isShown, videoData }: Prop) => {
+  const { like_count, user, id } = videoData;
+
+  return (
+    <S.Wrap isShown={isShown}>
+      <ProfileFollow userData={user} />
+      <LikeButton videoId={id} like_count={like_count} />
+      <ChatButton />
+      <MoreButton />
+    </S.Wrap>
+  );
+};

--- a/src/components/Main/NavMenu/UserVideoNav/styles.ts
+++ b/src/components/Main/NavMenu/UserVideoNav/styles.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const Wrap = styled.div<{ isShown: boolean }>`
+  display: ${props => (props.isShown ? 'flex' : 'none')};
+  position: absolute;
+  right: ${({ theme }) => theme.style.edge_padding};
+  bottom: 35px;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 1000;
+`;

--- a/src/components/Main/NavMenu/styles.ts
+++ b/src/components/Main/NavMenu/styles.ts
@@ -26,13 +26,6 @@ export const Button = styled.button`
     margin-top: 38px;
   }
 
-  img {
-    width: 48px;
-    height: 48px;
-    object-fit: cover;
-    border-radius: 50%;
-  }
-
   p {
     font-size: 12px;
     margin-top: 5px;

--- a/src/components/Profile/ProfileHeader/ProfileHeader.tsx
+++ b/src/components/Profile/ProfileHeader/ProfileHeader.tsx
@@ -4,8 +4,8 @@ import * as S from './styles';
 import { USER_DATA_API } from 'utils/api';
 import { fetcherWithToken } from 'utils/swr';
 import { IUserData } from 'types';
-import { Loading } from 'components/Common/Loading/Loading';
 import { useEffect, useState } from 'react';
+import { ProfileImage, Loading } from 'components';
 
 export const ProfileHeader = ({ userId }: { userId: number }) => {
   const { data } = useSWR(USER_DATA_API(userId), fetcherWithToken);
@@ -22,15 +22,7 @@ export const ProfileHeader = ({ userId }: { userId: number }) => {
     <S.Wrap>
       {userData ? (
         <>
-          <img
-            src={
-              userData.profile_image_url
-                ? userData.profile_image_url
-                : 'https://images.unsplash.com/photo-1651070216681-22fe5a718c06?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80'
-            }
-            alt="profile"
-            className="profile-img"
-          />
+          <ProfileImage size="100" url={userData.profile_image_url} />
           <div className="profile-username">
             <span>@{userData.name}</span>
           </div>

--- a/src/components/Profile/ProfileHeader/styles.ts
+++ b/src/components/Profile/ProfileHeader/styles.ts
@@ -7,18 +7,9 @@ export const Wrap = styled.div`
   align-items: center;
   margin-top: 20px;
 
-  .profile-img {
-    width: 100px;
-    height: 100px;
-    border-radius: 50%;
-    display: block;
-    margin-bottom: 10px;
-  }
-
   .profile-username {
-    span {
-      font-size: 15px;
-    }
+    margin-top: 10px;
+    font-size: 15px;
   }
 `;
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,6 +13,7 @@ export { LoginButton } from './Common/LoginButton/LoginButton';
 export { LoginModal } from './Common/Modal/LoginModal';
 export { DeleteModal } from './Common/Modal/DeleteModal';
 export { MessageModal } from './Common/Modal/MessageModal';
+export { ProfileImage } from './Common/ProfileImage/ProfileImage';
 
 // Profile
 export { ProfileHeader } from './Profile/ProfileHeader/ProfileHeader';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -31,8 +31,8 @@ export { MessageBox } from './ChatRoom/MessageBox/MessageBox';
 
 // Main
 export { VideoPlayer } from './Main/VideoPlayer/VideoPlayer';
-export { PlayerMenu } from './Main/NavMenu/PlayerMenu';
-export { ControlMenu } from './Main/NavMenu/ControlMenu';
+export { MyVideoNav } from './Main/NavMenu/MyVideoNav/MyVideoNav';
+export { UserVideoNav } from './Main/NavMenu/UserVideoNav/UserVideoNav';
 export { DescriptionBox } from './Main/DescriptionBox/DescriptionBox';
 export { MainHeader } from './Main/MainHeader/MainHeader';
 export { ContentsWrap } from './Main/ContentsWrap/ContentsWrap';

--- a/src/pages/ChatListPage/ChatListPage.tsx
+++ b/src/pages/ChatListPage/ChatListPage.tsx
@@ -13,11 +13,7 @@ export const ChatListPage = () => {
     <S.Wrap>
       <S.PageTitle>채팅</S.PageTitle>
       <AdBanner height="100px" />
-      {!userData ? (
-        <LoginModal />
-      ) : (
-        chatData && <ChatList chatList={chatData} />
-      )}
+      {userData ? <LoginModal /> : chatData && <ChatList chatList={chatData} />}
     </S.Wrap>
   );
 };

--- a/src/pages/FollowPage/FollowPage.tsx
+++ b/src/pages/FollowPage/FollowPage.tsx
@@ -1,9 +1,9 @@
 import { PageHeader } from 'components';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import useSWR from 'swr';
-import { IFollow, IUserData } from 'types';
-import { USER_DATA_API, FOLLOWER_API, FOLLOWING_API } from 'utils/api';
-import { fetcher, fetcherWithToken } from 'utils/swr';
+import { IFollow } from 'types';
+import { FOLLOWER_API, FOLLOWING_API } from 'utils/api';
+import { fetcher } from 'utils/swr';
 import * as S from './styles';
 
 interface RouteState {
@@ -15,9 +15,9 @@ interface RouteState {
 export const FollowPage = () => {
   const location = useLocation();
   const { state } = useLocation() as RouteState;
+  const userName = decodeURI(location.pathname.split('/')[1]);
   const page = location.pathname.split('/')[2];
 
-  const { data: user } = useSWR(USER_DATA_API(state.userId), fetcherWithToken);
   const { data: follow } = useSWR(
     page === 'following'
       ? FOLLOWING_API(state.userId)
@@ -25,21 +25,18 @@ export const FollowPage = () => {
     fetcher
   );
 
-  const userData = user?.data as IUserData;
   const followData = follow?.data as IFollow[];
 
-  console.log('follow', followData, 'userData', userData);
-
-  const pageTitle =
-    userData &&
-    `${userData.name}님의 ${page === 'following' ? '팔로잉' : '팔로워'}`;
+  const pageTitle = `${userName}님의 ${
+    page === 'following' ? '팔로잉' : '팔로워'
+  }`;
 
   const addFollowing = () => {};
   const deleteFollowing = () => {};
 
   return (
     <S.Wrap>
-      <PageHeader title={pageTitle} backTo="/profile" />
+      <PageHeader title={pageTitle} backTo={'/' + userName} />
       <S.FollowList>
         {followData &&
           followData?.map(({ id, member }) => (
@@ -52,7 +49,7 @@ export const FollowPage = () => {
                 alt="profile"
               />
               <S.Name>{member.name || ''}</S.Name>
-              {userData.name === localStorage.getItem('name') ? (
+              {userName === localStorage.getItem('name') ? (
                 page === 'following' ? (
                   <S.Button onClick={deleteFollowing}>삭제</S.Button>
                 ) : (

--- a/src/pages/FollowPage/FollowPage.tsx
+++ b/src/pages/FollowPage/FollowPage.tsx
@@ -1,4 +1,4 @@
-import { PageHeader } from 'components';
+import { PageHeader, ProfileImage } from 'components';
 import { useLocation } from 'react-router-dom';
 import useSWR from 'swr';
 import { IFollow } from 'types';
@@ -41,13 +41,7 @@ export const FollowPage = () => {
         {followData &&
           followData?.map(({ id, member }) => (
             <S.FollowItem key={id}>
-              <S.ProfileImg
-                src={
-                  member.profile_image_url ||
-                  'https://ussecuritysupply.com/wp-content/uploads/2013/05/default_avatar.png'
-                }
-                alt="profile"
-              />
+              <ProfileImage size="50" url={member.profile_image_url} />
               <S.Name>{member.name || ''}</S.Name>
               {userName === localStorage.getItem('name') ? (
                 page === 'following' ? (

--- a/src/pages/FollowPage/FollowPage.tsx
+++ b/src/pages/FollowPage/FollowPage.tsx
@@ -1,8 +1,14 @@
+import axios from 'axios';
 import { PageHeader, ProfileImage } from 'components';
 import { useLocation } from 'react-router-dom';
 import useSWR from 'swr';
 import { IFollow } from 'types';
-import { FOLLOWER_API, FOLLOWING_API } from 'utils/api';
+import {
+  FOLLOWER_API,
+  FOLLOWING_API,
+  FOLLOW_API,
+  UNFOLLOW_API
+} from 'utils/api';
 import { fetcher } from 'utils/swr';
 import * as S from './styles';
 
@@ -18,7 +24,7 @@ export const FollowPage = () => {
   const userName = decodeURI(location.pathname.split('/')[1]);
   const page = location.pathname.split('/')[2];
 
-  const { data: follow } = useSWR(
+  const { data: follow, mutate } = useSWR(
     page === 'following'
       ? FOLLOWING_API(state.userId)
       : FOLLOWER_API(state.userId),
@@ -31,8 +37,31 @@ export const FollowPage = () => {
     page === 'following' ? '팔로잉' : '팔로워'
   }`;
 
-  const addFollowing = () => {};
-  const deleteFollowing = () => {};
+  const addFollowing = (id: number) => {
+    axios
+      .post(FOLLOW_API(id), {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('AC_Token')}`
+        }
+      })
+      .then(() => {
+        mutate();
+      })
+      .catch(error => console.log(error));
+  };
+
+  const deleteFollowing = (id: number) => {
+    axios
+      .delete(UNFOLLOW_API(id), {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('AC_Token')}`
+        }
+      })
+      .then(() => {
+        mutate();
+      })
+      .catch(error => console.log(error));
+  };
 
   return (
     <S.Wrap>
@@ -45,9 +74,11 @@ export const FollowPage = () => {
               <S.Name>{member.name || ''}</S.Name>
               {userName === localStorage.getItem('name') ? (
                 page === 'following' ? (
-                  <S.Button onClick={deleteFollowing}>삭제</S.Button>
+                  <S.Button onClick={() => deleteFollowing(id)}>삭제</S.Button>
                 ) : (
-                  <S.Button onClick={addFollowing}>팔로우</S.Button>
+                  <S.Button onClick={() => addFollowing(member.id)}>
+                    팔로우
+                  </S.Button>
                 )
               ) : null}
             </S.FollowItem>

--- a/src/pages/FollowPage/styles.ts
+++ b/src/pages/FollowPage/styles.ts
@@ -20,13 +20,6 @@ export const FollowItem = styled.li`
   }
 `;
 
-export const ProfileImg = styled.img`
-  width: 50px;
-  height: 50px;
-  object-fit: cover;
-  border-radius: 50%;
-`;
-
 export const Name = styled.p`
   margin-left: 10px;
   font-weight: 500;

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -15,7 +15,7 @@ export const ProfilePage = () => {
   const { state } = useLocation() as RouteState;
 
   const isMyPage = username === localStorage.getItem('name');
-  const myId = localStorage.getItem('id') || '3';
+  const myId = localStorage.getItem('id') || '36';
   const userId = localStorage.getItem('profile-id') || state.userId + '';
 
   useEffect(() => {

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { ProfileHeader, ProfileNavigation } from 'components';
 import { useLocation, useParams } from 'react-router-dom';
 import * as S from './styles';
@@ -9,13 +10,27 @@ interface RouteState {
 }
 
 export const ProfilePage = () => {
+  const [current, setCurrent] = useState(0);
   const { username } = useParams();
   const { state } = useLocation() as RouteState;
 
+  const isMyPage = username === localStorage.getItem('name');
+  const myId = localStorage.getItem('id') || '3';
+  const userId = localStorage.getItem('profile-id') || state.userId + '';
+
+  useEffect(() => {
+    if (isMyPage) {
+      setCurrent(Number(myId));
+    } else {
+      localStorage.setItem('profile-id', userId);
+      setCurrent(Number(userId));
+    }
+  }, [isMyPage, myId, userId]);
+
   return (
     <S.Wrap>
-      <ProfileHeader userId={state.userId} />
-      <ProfileNavigation userId={state.userId} />
+      <ProfileHeader userId={current} />
+      <ProfileNavigation userId={current} />
     </S.Wrap>
   );
 };

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,4 +1,5 @@
 export interface IUser {
+  id: number;
   name: string;
   profile_image_url: string;
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -44,6 +44,12 @@ export const LIKE_API = (video_id: number) =>
 export const UNLIKE_API = (video_id: number) =>
   `${BASE_URL}/v1/videos/likes/${video_id}`;
 
+// Follow
+export const FOLLOW_API = (user_id: number) =>
+  `${BASE_URL}/v1/users/following/${user_id}`;
+export const UNFOLLOW_API = (follow_id: number) =>
+  `${BASE_URL}/v1/users/following/${follow_id}`;
+
 // Admin Page
 export const ADMIN_USER_API = (keyword: string) =>
   `${BASE_URL}/v1/users?keyword=${keyword}`;


### PR DESCRIPTION
### 세부 구현 사항들
- [x] 프로필과 팔로잉 페이지 이동 시  userId를 기억하여 라우팅 되도록 수정
- [x] 사용자가 설정한 이미지가 없는 경우 default 이미지를 보여주도록 ProfileImage 컴포넌트 생성
- [x] 메인 화면 프로필 팔로우 버튼 클릭 시 팔로잉 추가 
- [x] 마이프로필의 팔로워 페이지 팔로우 버튼 클릭 시 팔로잉 추가
- [x] 마이프로필의 팔로잉 페이지 삭제 버튼 클릭 시 팔로잉 삭제

### 전달 사항
1. NavMenu에 추가되는 기능들이 많은 것 같아서 버튼컴포넌트들 따로 분리시켰습니다
2. 내가 올린 비디오 Nav랑 유저가 올린 비디오 Nav 스타일 분리
3. 컴포넌트 이름도 좀 더 명시적으로 바꾸었으니 작업할 때  참고 해주세용
```
PlayerMenu 👉 UserVideoNav
ControlMenu 👉 MyVideoNav
```