### PR TITLE
:sparkles: 소셜로그인시 id값 로컬스토리지에 저장, 디버깅 코드 추가

### DIFF
--- a/src/components/Login/KakaoLogin/KakaoRedirectHandler.tsx
+++ b/src/components/Login/KakaoLogin/KakaoRedirectHandler.tsx
@@ -17,16 +17,17 @@ export const KakaoRedirectHandler = () => {
           })
           // 서버에서 발행한 자체 JWT 토큰 받기
           .then(res => {
-            // console.log(res.data);
+            console.log(res.data);
 
             if (res.data.message !== '로그인 성공') {
               alert('로그인에 성공하지 못했습니다.');
             }
 
-            const { name, email, token } = res.data.data;
+            const { id, name, email, token } = res.data.data;
             const accessToken = token.accessToken;
             const refreshToken = token.refreshToken;
             // let refreshToken = res.headers['refresh-token'];
+            localStorage.setItem('profile-id', id);
             localStorage.setItem('name', name);
             localStorage.setItem('email', email);
             localStorage.setItem('AC_Token', accessToken);
@@ -40,7 +41,7 @@ export const KakaoRedirectHandler = () => {
       //리다이렉트 페이지에서 인가코드 분리
       const url = new URL(window.location.href);
       const authorizationCode = url.searchParams.get('code');
-      // console.log('인증 코드', authorizationCode);
+      console.log('인증 코드', authorizationCode);
 
       if (authorizationCode) {
         await geJWTToken(authorizationCode);


### PR DESCRIPTION
### 세부구현 사항

- [x] 카카오 로그인시 id값 localstorage 저장
- [x] 카카오 로그인 오류 디버깅을 위한 콘솔로그 추가